### PR TITLE
use spectral width for x data in nmr jcamp generation

### DIFF
--- a/demo/bruker-to-jcamp.ts
+++ b/demo/bruker-to-jcamp.ts
@@ -55,7 +55,6 @@ function writeJcamps(spectra) {
         isNMR: true,
       };
 
-      // the order of variables in the object is important
       const variables = {
         x: {
           data: xMultiply(data.x, observeFrequency),

--- a/src/__tests__/from1DNMRVariables.test.ts
+++ b/src/__tests__/from1DNMRVariables.test.ts
@@ -37,6 +37,10 @@ describe('convert bruker to jcamp', () => {
       spectra[0].spectra[0].data.x[0],
       3,
     );
+    expect(converted.spectra[0].data.y[0]).toBeCloseTo(
+      spectra[0].spectra[0].data.re[0],
+      3,
+    );
     expect(converted.spectra).toHaveLength(2);
   });
   it('FFT bruker expno only real', async () => {
@@ -55,6 +59,10 @@ describe('convert bruker to jcamp', () => {
     expect(converted.meta).toStrictEqual(spectra[0].meta);
     expect(converted.spectra[0].data.x[0]).toBeCloseTo(
       spectra[0].spectra[0].data.x[0],
+      3,
+    );
+    expect(converted.spectra[0].data.y[0]).toBeCloseTo(
+      spectra[0].spectra[0].data.re[0],
       3,
     );
     expect(converted.spectra).toHaveLength(1);

--- a/src/__tests__/from1DNMRVariables.test.ts
+++ b/src/__tests__/from1DNMRVariables.test.ts
@@ -33,10 +33,35 @@ describe('convert bruker to jcamp', () => {
     ).flatten[0];
 
     expect(converted.meta).toStrictEqual(spectra[0].meta);
+    expect(converted.spectra[0].data.x[0]).toBeCloseTo(
+      spectra[0].spectra[0].data.x[0],
+      3,
+    );
+    expect(converted.spectra).toHaveLength(2);
+  });
+  it('FFT bruker expno only real', async () => {
+    const fileList = getCoffee();
+    const oneExpno = fileList.filter((file) =>
+      file.webkitRelativePath.includes(
+        'UV1009_M1-1003-1002_6268712_73uEjPg4XR/20',
+      ),
+    );
+    const spectra = await convertFileList(oneExpno, converterOptions);
+    const jcamp = getJcamp(spectra[0], 'real') || '';
+    const converted = parse(
+      stringify(convert(jcamp, { keepRecordsRegExp: /^\$.*/ })),
+    ).flatten[0];
+
+    expect(converted.meta).toStrictEqual(spectra[0].meta);
+    expect(converted.spectra[0].data.x[0]).toBeCloseTo(
+      spectra[0].spectra[0].data.x[0],
+      3,
+    );
+    expect(converted.spectra).toHaveLength(1);
   });
 });
 
-function getJcamp(spectrum: any) {
+function getJcamp(spectrum: any, selection = 'complex') {
   const { source } = spectrum;
   if (source.is1D && !source.isFID) {
     const { info, meta, spectra } = spectrum;
@@ -70,14 +95,17 @@ function getJcamp(spectrum: any) {
         symbol: 'R',
         isDependent: true,
       },
-      i: {
+    } as MeasurementXYVariables;
+
+    if (selection === 'complex') {
+      variables.i = {
         data: data.im,
         label: 'imaginary data',
         units: 'arbitratry units',
         symbol: 'I',
         isDependent: true,
-      },
-    } as MeasurementXYVariables;
+      };
+    }
 
     return from1DNMRVariables(variables, options);
   }

--- a/src/from1DNMRVariables.ts
+++ b/src/from1DNMRVariables.ts
@@ -75,7 +75,7 @@ export function from1DNMRVariables(
     origin = '',
     dataType = 'NMR SPECTRUM',
     nucleus = info['.OBSERVE NUCLEUS'],
-    observeFrequency = info['.OBSERVE FREQUENCY'],
+    originFrequency = info['.OBSERVE FREQUENCY'],
   } = info;
 
   if (isRealData(variables)) {
@@ -85,55 +85,54 @@ export function from1DNMRVariables(
     );
   }
 
-  if (!observeFrequency) {
+  if (!originFrequency) {
     throw new Error(
       '.OBSERVE FREQUENCY is mandatory into the info object for nmr data',
     );
   }
 
-  if (!info['.OBSERVE FREQUENCY']) {
-    info['.OBSERVE FREQUENCY'] = observeFrequency;
+  const newInfo = {
+    '.OBSERVE FREQUENCY': originFrequency,
+    '.OBSERVE NUCLEUS': nucleus,
+    ...info,
+  };
+
+  const newVariables = checkDescending(variables);
+  const xVariable = newVariables.x as MeasurementVariable<DoubleArray>;
+
+  let xData = xVariable.data;
+  if (xVariable.units?.toLowerCase() !== 'hz') {
+    xData = xMultiply(xData, originFrequency);
   }
-  if (!info['.OBSERVE NUCLEUS']) info['.OBSERVE NUCLEUS'] = nucleus;
 
-  const xVariable = variables.x as MeasurementVariable<DoubleArray>;
-  const reverse = xVariable.data[0] < xVariable.data[1];
-
-  if (reverse) xVariable.data.reverse();
-  if (variables.x?.units?.toLowerCase() !== 'hz') {
-    xVariable.data = xMultiply(xVariable.data, observeFrequency);
-  }
-
-  const nbPoints = xVariable.data.length;
-  const spectralWidth = xVariable.data[0] - xVariable.data[nbPoints - 1];
+  const nbPoints = xData.length;
+  const spectralWidth = xData[0] - xData[nbPoints - 1];
   const symbol = ['X'];
-  const varName = [variables.x?.label.replace(/ *\[.*/, '') || 'X'];
+  const varName = [xVariable.label.replace(/ *\[.*/, '') || 'X'];
   const varType = ['INDEPENDENT'];
-  const varDim = [xVariable.data.length];
+  const varDim = [xData.length];
   const units = ['Hz'];
   const first = [spectralWidth];
   const last = [0];
   const min = [0];
   const max = [spectralWidth];
-  const factorArray = [xVariable.data.length / spectralWidth];
+  const factorArray = [xData.length / spectralWidth];
 
-  const keys = isPeakData(variables) ? peakDataKeys : ntuplesKeys;
+  const keys = isPeakData(newVariables) ? peakDataKeys : ntuplesKeys;
 
   for (const key of keys) {
-    let variable = variables[key];
+    let variable = newVariables[key];
 
     if (!variable) {
       if (key !== 'i') {
         throw new Error(
           `variable ${key} is mandatory in ${
-            isPeakData(variables) ? 'peak' : 'real/imaginary'
+            isPeakData(newVariables) ? 'peak' : 'real/imaginary'
           } data`,
         );
       }
       continue;
     }
-
-    if (reverse) variable.data.reverse();
 
     let name = variable?.label.replace(/ *\[.*/, '');
     let unit = variable?.label.replace(/.*\[(?<units>.*)\].*/, '$<units>');
@@ -165,11 +164,11 @@ export function from1DNMRVariables(
 ##ORIGIN=${origin}
 ##OWNER=${owner}\n`;
 
-  const infoKeys = Object.keys(info).filter(
+  const infoKeys = Object.keys(newInfo).filter(
     (e) =>
       !['title', 'owner', 'origin', 'datatype'].includes(e.toLocaleLowerCase()),
   );
-  header += addInfoData(info, infoKeys, '##');
+  header += addInfoData(newInfo, infoKeys, '##');
   header += addInfoData(meta);
 
   header += `##NTUPLES= ${dataType}
@@ -183,17 +182,17 @@ export function from1DNMRVariables(
 ##MAX=       ${max.join()}
 ##MIN=       ${min.join()}\n`;
 
-  if (isPeakData(variables)) {
-    let xData = variables.x.data;
-    let yData = variables.y.data;
+  if (isPeakData(newVariables)) {
+    let xData = newVariables.x.data;
+    let yData = newVariables.y.data;
     checkNumberOrArray(yData);
     header += `##DATA TABLE= (XY..XY), PEAKS\n`;
     for (let point = 0; point < varDim[0]; point++) {
       header += `${xData[point]}, ${yData[point]}\n`;
     }
-  } else if (isNTuplesData(variables)) {
+  } else if (isNTuplesData(newVariables)) {
     for (const key of ['r', 'i'] as const) {
-      const variable = variables[key];
+      const variable = newVariables[key];
 
       if (!variable) continue;
 
@@ -205,7 +204,7 @@ export function from1DNMRVariables(
       })), XYDATA\n`;
       header += vectorEncoder(
         rescaleAndEnsureInteger(variable.data, factor[key]),
-        xVariable.data.length - 1,
+        xData.length - 1,
         -1,
         xyEncoding,
       );
@@ -216,4 +215,21 @@ export function from1DNMRVariables(
   header += `##END NTUPLES= ${dataType}\n`;
   header += '##END=';
   return header;
+}
+
+function checkDescending(variables: NMR1DVariables) {
+  const xVariable = variables.x as MeasurementVariable<DoubleArray>;
+  const reverse = xVariable.data[0] < xVariable.data[1];
+
+  if (!reverse) return variables;
+
+  const newVariables = JSON.parse(
+    JSON.stringify(variables, (key, value) =>
+      ArrayBuffer.isView(value) ? Array.from(value as any) : value,
+    ),
+  );
+  for (const key of ['x', 'r', 'i'] as Array<keyof NtuplesData>) {
+    newVariables[key]?.data.reverse();
+  }
+  return newVariables;
 }

--- a/src/from1DNMRVariables.ts
+++ b/src/from1DNMRVariables.ts
@@ -87,7 +87,6 @@ export function from1DNMRVariables(
   }
 
   meta.OFFSET = xData[0] / originFrequency;
-  const isFid = xVariable.units?.toLowerCase() === 'time';
 
   let header = `##TITLE=${title}
 ##JCAMP-DX=6.00
@@ -100,8 +99,10 @@ export function from1DNMRVariables(
   }\n`; //TOPSPIN use this LDR to generate x axis.
 
   const infoKeys = Object.keys(newInfo).filter(
-    (e) =>
-      !['title', 'owner', 'origin', 'datatype'].includes(e.toLocaleLowerCase()),
+    (key) =>
+      !['title', 'owner', 'origin', 'datatype'].includes(
+        key.toLocaleLowerCase(),
+      ),
   );
   header += addInfoData(newInfo, infoKeys, '##');
   header += addInfoData(meta);
@@ -121,8 +122,8 @@ export function from1DNMRVariables(
   const first = [firstPoint];
   const last = [lastPoint];
 
-  const max = [firstPoint];
-  const min = [isFid ? xData[nbPoints - 1] : 0];
+  const max = [Math.max(lastPoint, firstPoint)];
+  const min = [Math.min(lastPoint, firstPoint)];
 
   for (const key of ntuplesKeys) {
     let variable = variables[key];


### PR DESCRIPTION
reduce size of jcamp using the spectral width and the number of points it is similar to the exported jcamp from bruker topspin